### PR TITLE
Add systemd service files for Python server and reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,118 +133,91 @@ This should open the Fortran playground in your default web browser.
 If not, navigate to http://localhost:3000 in your browser to start the
 playground.
 
+## Deploying to production
+
+This is a guide for deploying the Python backend to production.
+
+### Set up the VM
+
+This is a setup guide to host the server on AWS EC2.
+It assumes you already have an account.
+The steps may be somewhat different on other cloud providers.
+
+1. Start the EC2 Launch Instance Wizard.
+2. Select Ubuntu 22.04 LTS x86 as your OS under the AMI section.
+2. Select the `t2.micro` instance if you want to stay within the free tier and
+keep the configuration as default.
+3. Select the amount storage you need; 20 GBs will suffice and will stay under
+the free tier. Go to next step and leave tags as default.
+4. Configure the security group to allow:
+  * SSH on port 22;
+  * HTTP on port 80;
+  * HTTPS on port 443;
+All ports should allow the source to be "Anywhere", i.e. 0.0.0.0/0.
+5. Select or create your SSH key pair, and keep your private key safe.
+
+Next, attach an Elastic IP to this instance so that the VM receives a static IP
+address.
+
+1. Select Elastic IP in the navigation panel, and create a new Elastic IP.
+2. Associate this Elastic IP to the instance you've just created.
+3. Go to your instance and note this Elastic IP
+  (you'll see it listed under the v4 IP address).
+
+### Connect to and prepare the VM
+
+1. Locate your SSH private key file that you created or selected in step 5
+and connect to your server by using SSH:
+```
+ssh -i <pem-file> ubuntu@<public-ip-address>
+```
+2.  Update your instance
+```
+sudo apt update
+sudo apt upgrade
+```
+If prompted to reboot after the upgrade is complete, reboot the VM from the AWS
+control panel and log back in to the VM using SSH as described in the previous
+step.
+3. Download [Caddy](https://caddyserver.com).
+We will use Caddy as a reverse-proxy server in front of the Python server
+as well as for the SSL certificate.
+The downloaded file is a static binary program.
+Make it executable (`chmod +x caddy`) and place it in a directory that is
+meant for external programs, for example `/opt/caddy-2.5.2/bin` or similar.
+This guide, and the
+[reverse-proxy service file](systemd/playground-reverse-proxy.service)
+assume that Caddy is executable and present in `/opt/caddy-2.5.2/bin`.
+3. Follow the instructions from the [Getting started section](#getting-started)
+to get the playground code, install Docker and the Python backend dependencies.
+Before running the `pipenv install` step for the Python backend, make a
+directory for the virtual environment using `mkdir .venv`.
+This will allow us to run the production server directly from
+`playground/backend/.venv/bin`.
+
+### Create or update the DNS record
+
+This guide assumes that the backend server of the Fortran Playground
+will serve at the play-api.fortran-lang.org subdomain.
+Regardless of whether this is the first deployment to production or not,
+ensure that there is an A record for play-api.fortran-lang.org that
+points to the public IP address of the VM.
+
+### Start the backend server and reverse proxy
+
+systemd service files for the Python backend server and reverse proxy
+are provided in the playground/systemd directory.
+To start and enable the services, type:
+
+```
+cd systemd
+sudo ./initialize-services.sh
+```
+
+which will copy the service files to `/etc/systemd/system`,
+start them, and enable them so they start on every boot.
+
 ## Reporting issues
 
 Please report any issues or suggestions for improvement by opening a
 [new GitHub issue](https://github.com/fortran-lang/playground/issues/new).
-
-## Production Guide
-This is a setup guide to host the server on AWS EC2. It's assuming you already have an account setup and know about free tier limitations.
-#### Setting up EC2 
-1.  Select the EC2 Launch Instance Wizard choose Ubuntu(22.04 x86) as your OS under AMI section. 
-2. Choose t2.micro instance if you want to stay within free tier or your preferred instance type and head to  the next section.  Keep configuration as default.
-3.  Select the storage you need, 20 GBs should be more than enough and it'll still stay under free tier. Go to next step and leave tags as default.
-4. Configure the security group as follows:
-![security group](https://imgur.com/a/zGTCN6F)
-5.  Click next to choose your key pair.(You'll be connecting to SSH via this key so keep it safe, if you don't have one already generate a new one)
-
-Now, we need to attach an Elastic IP to this instance, as instances are allocated only a dynamic IP, also free tier only allows 1 hour of use without  an elastic IP. 
-
-1. Select Elastic IP in the navigation pane, and generate a new Elastic IP.
-2. Associate this Elastic IP to the instance you've just created.
-3. Go to your instance and copy this Elastic IP(you'll see it listed under the v4 IP address)
-
-#### Setting up the EC2 instance
-1. Locate your key.pem file you generated in step 5 and connect to your server by using SSH:
-```
-sudo ssh -i <pem file> ubuntu@<Public IP of the EC2 instance>
-```
-2.  Update your instance
-```sudo apt-get update```
-3.  Install pip
-```sudo apt install python3-pip```
-4.  Install nginx
-`sudo apt-get install nginx`
-5 Install node.js and npm using nvm.
-Get NVM
-``curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash`
-``
-Activate nvm
-`. ~/.nvm/nvm.sh`
-Install node
-`nvm install --lts`
-
-####  Setting up the playground on VM
-1.  Clone the repository
-`git clone https://github.com/fortran-lang/playground.git`
-2.  Assign all read and write permissions to the project directory
-```sudo chmod 777 playground```
-```cd playground```
-3.  Go to frontend directory`cd playground/frontend`, before we build a production version we need to replace our API calls with the public IP.
-	a. Open App.js file which has our API call:
-	`sudo nano playground/frontend/src/App.js`
-	b. Replace the http://127.0.0.1:5000 url with http://{your public ip}:5000
-
-4. Install modules `npm install`, create a build from those modules `npm run build`
-4. Create a directory for the frontend with the following command:
-`sudo mkdir /var/www/html/react`
-Next, copy all contents from the build directory to the react directory:
-`sudo cp -r /home/ubuntu/playground/frontend/build/* /var/www/html/react/`
-
-5.  To go on, set proper ownership of the react directory with the following command:
-`sudo chown -R www-data:www-data /var/www/html/react`
-6. Next, create an Nginx virtual host configuration file to host your React app.
-`nano /etc/nginx/conf.d/react.conf`
-add this to the file:
-`server {
-         listen 80;
-         listen [::]:80;
-         root /var/www/html/react/;
-         index index.html index.htm;
-         # MODIFY SERVER_NAME EXAMPLE
-         location / {
-              try_files $uri $uri/ =404;
-         }
-}`
-7. Restart nginx
-`systemctl restart nginx`
-
-####Setting up Docker
-Refer this link for [setting up docker](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository "setting up docker") (setup via repository).
-After successfully installing docker switch to the Docker directory `cd playground/backend/docker`
-and build the docker image `sudo docker build -t playground-prod .` .
-
-#### Setting up the backend server
-1.  Go to the backend folder `cd playground/backend`.
-2. Install pipenv to install packages from the pipfile
-  `sudo pip install pipenv`
-3. Make a directory for virtual environment(this will be useful when setting up the service) using `mkdir .venv` and install all required modules using `pipenv install` 
-4. Start the server using:
-```sudo pipenv run gunicorn --bind 0.0.0.0:5000 wsgi:app```
-
-You'll now be able to use the app. You should also setup a service for the gunicorn server so that it starts automatically when the server boots. 
-
-#### Setting up the service
-1. Create a service file for our app `sudo nano /etc/systemd/system/backend.service`
-2. Write the following configuration: 
-```
-[Unit]
-Description=Gunicorn instance to serve backend for playground
-After=network.target
-[Service]
-User=ubuntu
-Group=www-data
-WorkingDirectory=/home/ubuntu/playground/backend
-Environment="PATH=/home/ubuntu/playground/backend/.venv/bin"
-ExecStart=sudo /home/ubuntu/playground/backend/.venv/bin/gunicorn --workers 3 -b :5000 wsgi:app
-[Install]
-WantedBy=multi-user.target
-```
-Press Ctrl + X and save the file.
-3. Start the service using `sudo systemctl start backend`
-4. Then enable it so that it starts at boot:
-  `sudo systemctl enable myproject`
-
-Now, You'll can directly cater requests to the port and your app should work. I recommend using a 
-reverse proxy for your requests by altering the nginx configuration and adding an endpoint
-for the API.

--- a/systemd/initialize-services.sh
+++ b/systemd/initialize-services.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script initializes the systemd services.
+# This is useful to do when setting up the Fortran Playground background server
+# on a new machine or VM for the first time.
+# Run it as `sudo initialize-services.sh`.
+
+for service in playground-server playground-reverse-proxy; do
+  echo Copying $service.service to /etc/systemd/system/.
+  cp $service.service /etc/systemd/system/.
+  echo Starting and enabling service $service
+  systemctl start $service
+  systemctl enable $service
+done

--- a/systemd/playground-reverse-proxy.service
+++ b/systemd/playground-reverse-proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reverse proxy and SSL for the Fortran Playground server
+After=network.target
+
+[Service]
+ExecStart=/opt/caddy-2.5.2/bin/caddy reverse-proxy --from play-api.fortran-lang.org --to localhost:5000
+WorkingDirectory=/home/ubuntu
+StandardOutput=file:/home/ubuntu/playground-reverse-proxy_stdout.log
+StandardError=file:/home/ubuntu/playground-reverse-proxy_stderr.log
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/playground-server.service
+++ b/systemd/playground-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fortran Playground server
+
+[Service]
+ExecStart=/home/ubuntu/playground/backend/.venv/bin/gunicorn --workers 3 --timeout 600 --reload --access-logfile access.log --log-file error.log --bind 0.0.0.0:5000 wsgi:app
+WorkingDirectory=/home/ubuntu/playground/backend
+Restart=always
+StandardOutput=file:/home/ubuntu/playground-server_stdout.log
+StandardError=file:/home/ubuntu/playground-server_stderr.log
+User=ubuntu
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds systemd service files for the Python server and for the reverse proxy (using Caddy) for use when deploying to production.

* [x] systemd service files
* [x] update README.md