### PR TITLE
Don't hardcode the API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,20 @@ npm install
 Run the server by typing:
 
 ```
-npm start
+REACT_APP_PLAYGROUND_API_URL=http://localhost:5000 npm start
 ```
 
 This should open the Fortran playground in your default web browser.
 If not, navigate to http://localhost:3000 in your browser to start the
 playground.
+
+The `REACT_APP_PLAYGROUND_API_URL` must be set in the environment
+(or, alternatively, in the `.env` file in the `frontend/` directory)
+to the URL value of the Python backend server to use.
+For example, if you're running the Python backend server locally in development
+mode, set `REACT_APP_PLAYGROUND_API_URL` to `http://localhost:5000`.
+If deploying to production, `REACT_APP_PLAYGROUND_API_URL` should be set to
+`https://play-api.fortran-lang.org`.
 
 ## Reporting issues
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -95,10 +95,14 @@ const tutfunc = (TutorialCode) =>{
     
     setOutput('')
     setIsLoading(true);
-      // POST request using axios inside useEffect React hook
-            await axios.post('http://127.0.0.1:5000/run', {code : text, programInput: input, libs: libs})
-          .then((response) => {setOutput(response.data.executed)});
-          setIsLoading(false);
+
+    // POST request using axios inside useEffect React hook
+    console.log(process.env)
+    await axios.post(`${process.env.REACT_APP_PLAYGROUND_API_URL}/run`, {code : text, programInput: input, libs: libs})
+               .then((response) => {setOutput(response.data.executed)});
+
+    setIsLoading(false);
+
   }
 
     //reset code button

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -97,7 +97,6 @@ const tutfunc = (TutorialCode) =>{
     setIsLoading(true);
 
     // POST request using axios inside useEffect React hook
-    console.log(process.env)
     await axios.post(`${process.env.REACT_APP_PLAYGROUND_API_URL}/run`, {code : text, programInput: input, libs: libs})
                .then((response) => {setOutput(response.data.executed)});
 


### PR DESCRIPTION
Provide it as an environment variable or from the .env file instead.

The env variable to set is `REACT_APP_PLAYGROUND_API_URL`. The `REACT_APP_` part is necessary due to a quirk with react-scripts. The remainder we can change if there are better ideas. It's quite long but it's the best I could come up with.

I also updated the README.md to reflect this change.