### PR TITLE
Initial support for responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+frontend/node_modules

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13,7 +13,7 @@
   display:  flex;
   flex-direction: column;
   justify-content: space-around;
-  
+
 }
 
 .run-button{
@@ -33,7 +33,7 @@
 }
 .linkText:hover{
   color:#B3B6B7;
-  
+
 }
 
 .options{
@@ -41,7 +41,7 @@
   display: flex;
   flex-direction: column;
   width: 4em;
-  
+
 }
 
 .output-formmating{
@@ -59,4 +59,3 @@
   align-items: center;
   margin: 2px;
 }
-

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -59,3 +59,29 @@
   align-items: center;
   margin: 2px;
 }
+
+/*Custom theming for bootstrap buttons*/
+.btn-run {
+  background-color: #734f96  !important;
+  color: white;
+}
+.btn-run:hover{
+  background-color: #009900 !important;
+  color: white;
+}
+.btn-run:active:focus{
+  background-color: #734f96  !important;
+  color: white;
+}
+.btn-lib{
+  background-color: #FF8E00  !important;
+  color: white;
+}
+.btn-lib:hover{
+  background-color: #FF8E00 !important;
+  color: white;
+}
+.btn-lib:active:focus{
+  background-color: #ed8502 !important;
+  color: white;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,7 +7,7 @@
 
 .terminal{
   height: 35rem;
-  width: 40%;
+  width: 50%;
   border: 2px solid black;
   padding: 0.2rem;
   display:  flex;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -136,39 +136,7 @@ const tutfunc = (TutorialCode) =>{
         <Button title="Libraries" className="selector" variant="lib" onClick={handleShow}><img alt="libs button"  src={Librarylogo} /></Button>
         <Button title="Run" className="selector" variant="run" onClick={handleClick}><img alt="run button" src={RunCode} /></Button>
       </div>
-      <div className='run-button'>
-        {/*Custom theming for bootstrap buttons*/}
-        <style type="text/css">
-            {`
-        .btn-run {
-          background-color: #734f96;
-          color: white;
-        }
-        .btn-run:hover{
-          background-color: #009900 !important;
-          color: white;
-        }
-        .btn-run:active:focus{
-          background-color: #734f96;
-          color: white;
-        }
-        .btn-lib{
-          background-color: #FF8E00;
-          color: white;
-        }
-        .btn-lib:hover{
-          background-color: #FF8E00 !important;
-          color: white;
-        }
-        .btn-lib:active:focus{
-          background-color: #ed8502;
-          color: white;
-        }
-        `}
-        </style>
 
-
-      </div>
       {/*Card component to display output*/}
       <div className='terminal'>
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -45,9 +45,9 @@ function App() {
     if(exercise<Tutorial.length - 1){
     setExercise(exercise + 1)
     }
-      
+
       tutfunc(Tutorial[exercise+1].code)
-      
+
   }
   const goLeft = () => {
     if(exercise>0){
@@ -71,7 +71,7 @@ function App() {
     }
 
   };
-  
+
 //Changing code inside editor for tutorial
 const tutfunc = (TutorialCode) =>{
   setText(TutorialCode)
@@ -94,7 +94,7 @@ const tutfunc = (TutorialCode) =>{
   }
   //POST request to Flask server
   const handleClick = async () => {
-    
+
     setOutput('')
     setIsLoading(true);
 
@@ -124,14 +124,14 @@ const tutfunc = (TutorialCode) =>{
   return (
     <div className="App" onLoad={loadCode} tabIndex={0} onKeyDown={handleKeyDown}>
       {/*Navbar*/}
-      <div style={{paddingBottom: "0.5rem"}}><Navigationbar/></div> 
+      <div style={{paddingBottom: "0.5rem"}}><Navigationbar/></div>
       <div className='code-wrapper'>
       {/*Editor Component*/}
       <Editor value={text} height={""} width={"50%"} onChange={value => setText(value)}/>
-      
+
       {/* Buttons */}
       <div className='options'>
-        
+
         <Button title="Reset Editor" className="selector" onClick={resetCode} ><img alt="reset button"  src={ResetCode} /></Button>
         <Button title="Libraries" className="selector" variant="lib" onClick={handleShow}><img alt="libs button"  src={Librarylogo} /></Button>
         <Button title="Run" className="selector" variant="run" onClick={handleClick}><img alt="run button" src={RunCode} /></Button>
@@ -166,59 +166,59 @@ const tutfunc = (TutorialCode) =>{
         }
         `}
         </style>
-        
-        
+
+
       </div>
       {/*Card component to display output*/}
       <div className='terminal'>
-        
+
           <Card style={{width:'100%'}} className="overflow-auto">
             <Card.Header>Output</Card.Header>
             <Card.Body>
-              
+
               <Card.Text>
                 {/* Spinning Animation While Request is processed */}
               {isLoading ? <p className='loading'><Spinner animation="border" size="sm" /></p> : null}
                 <NewlineText text={output} />
               </Card.Text>
-             
+
             </Card.Body>
           </Card>
-          
-          
+
+
           {/*Tutorial Card Component */}
           {showTutorial
            ? <>
-           <TutorialCard title={Tutorial[exercise].title} content={Tutorial[exercise].content} /> 
+           <TutorialCard title={Tutorial[exercise].title} content={Tutorial[exercise].content} />
            <div className='tutButton'><Button onClick={goLeft} >Prev</Button>&nbsp;
            <Button onClick={goRight}>Next</Button></div>
             </>
-          
-           : 
+
+           :
            <Card>
            <Card.Title style={{padding: '0.4em'}}>Welcome to the Fortran Playground</Card.Title>
            <Card.Body>
               <p>Use the editor on the left to type your code,
                you can select your <span style={{color: "#FF8E00", fontWeight: "bold" }}>libraries </span>
                 and provide <span style={{color: "#0d6efd", fontWeight: "bold" }}>custom input</span> for your code
-                using the respective buttons.</p> 
+                using the respective buttons.</p>
                <p>New to Fortran?
                  <p>Try our Quickstart Tutorial</p>
                  <Button onClick={startTutorial}>Start</Button>
                </p>
           </Card.Body>
          </Card>
-           
-          }     
-          
+
+          }
+
           {/* Input Box to provide input for program */}
           <br/>
           <Button onClick={handleInputBox}>User Input</Button>
           {inputOn ? <InputBox value={input} onChange={handleInputChange}/> : null} {/*toggle for input */}
 
-                
-          
-            
+
+
+
           {/*Library selector pop-up modal */}
             <Modal show={show} onHide={handleClose}>
               <Modal.Header closeButton>
@@ -226,7 +226,7 @@ const tutfunc = (TutorialCode) =>{
               </Modal.Header>
               <Modal.Body>Please select the packages you want
                     <Form>
-                            <Form.Check 
+                            <Form.Check
                               type="switch"
                               id="custom-switch"
                               label="stdlib"
@@ -245,9 +245,9 @@ const tutfunc = (TutorialCode) =>{
               </Modal.Footer>
             </Modal>
           </div>
-          
-      
-      
+
+
+
       </div>
     </div>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -195,7 +195,7 @@ const tutfunc = (TutorialCode) =>{
             </>
 
            :
-           <Card>
+           <Card style={{ width: '100%', height: '70%' }} className="overflow-scroll">
            <Card.Title style={{padding: '0.4em'}}>Welcome to the Fortran Playground</Card.Title>
            <Card.Body>
               <p>Use the editor on the left to type your code,

--- a/frontend/src/Navbar.js
+++ b/frontend/src/Navbar.js
@@ -2,10 +2,9 @@ import logo from "./fortran-logo.png"
 import Navbar from 'react-bootstrap/Navbar'
 import Nav from  'react-bootstrap/Nav'
 import Container from 'react-bootstrap/Container'
+
 export default function Navigationbar(){
     return(
-                
-        
         <Navbar bg="dark" variant="dark">
             <Container>
             <Navbar.Brand href="#home">
@@ -28,9 +27,6 @@ export default function Navigationbar(){
             <Nav.Link href="https://github.com/fortran-lang/playground" target="_blank" rel="noopener noreferrer" ><
                 span className="linkText">Github</span>
             </Nav.Link>&nbsp;&nbsp;&nbsp;
-
         </Navbar>
-        
-        
     )
 }

--- a/frontend/src/Navbar.js
+++ b/frontend/src/Navbar.js
@@ -1,12 +1,10 @@
 import logo from "./fortran-logo.png"
 import Navbar from 'react-bootstrap/Navbar'
 import Nav from  'react-bootstrap/Nav'
-import Container from 'react-bootstrap/Container'
 
 export default function Navigationbar(){
     return(
-        <Navbar bg="dark" variant="dark">
-            <Container>
+        <Navbar className="px-3" bg="dark" variant="dark" expand="lg">
             <Navbar.Brand href="#home">
                 <img
                 alt=""
@@ -15,18 +13,22 @@ export default function Navigationbar(){
                 height="30"
                 className="d-inline-block align-top"
                 />{' '}
-            Fortran Playground
+                Fortran Playground
             </Navbar.Brand>
-            </Container>
-            <Nav.Link href="https://fortran-lang.org/" target="_blank" rel="noopener noreferrer" >
-                <span className="linkText">Home</span>
-            </Nav.Link>&nbsp;
-            <Nav.Link href="https://fortran-lang.org/learn/" target="_blank" rel="noopener noreferrer" >
-                <span className="linkText">Learn</span>
-            </Nav.Link>&nbsp;
-            <Nav.Link href="https://github.com/fortran-lang/playground" target="_blank" rel="noopener noreferrer" ><
-                span className="linkText">Github</span>
-            </Nav.Link>&nbsp;&nbsp;&nbsp;
+            <Navbar.Toggle aria-controls="basic-navbar-nav" />
+            <Navbar.Collapse id="basic-navbar-nav" className="justify-content-end">
+                <Nav className="justify-content-end">
+                    <Nav.Link href="https://fortran-lang.org/" target="_blank" rel="noopener noreferrer" >
+                        <span className="linkText">Home</span>
+                    </Nav.Link>
+                    <Nav.Link href="https://fortran-lang.org/learn/" target="_blank" rel="noopener noreferrer" >
+                        <span className="linkText">Learn</span>
+                    </Nav.Link>
+                    <Nav.Link href="https://github.com/fortran-lang/playground" target="_blank" rel="noopener noreferrer" >
+                        <span className="linkText">Github</span>
+                    </Nav.Link>
+                </Nav>
+            </Navbar.Collapse>
         </Navbar>
     )
 }

--- a/frontend/src/TutorialCard.js
+++ b/frontend/src/TutorialCard.js
@@ -9,18 +9,18 @@ function NewlineText(props) {
 
 
 function TutorialCard(props) {
-  
-  
+
+
   return (
     <Card style={{ width: '100%', height: '50%' }} className="overflow-auto">
-      
+
       <Card.Body>
         <Card.Title>{props.title}</Card.Title>
-        
+
         <Card.Text>
           <NewlineText text={props.content} />
         </Card.Text>
-        
+
       </Card.Body>
     </Card>
   );


### PR DESCRIPTION
towards #41 

This PR improves the following:
- Makes the Navbar responsive
- Fixes the overflow of tutorial start banner
- And other minor fixes/improvements

**Output (Desktop):**

![image](https://user-images.githubusercontent.com/43722035/214566794-79183a41-f165-410b-987b-6df383de134a.png)

**Output (Potrait):**

<img alt="potrait-image" src="https://user-images.githubusercontent.com/43722035/214567203-aee67221-c0ce-4680-b853-f15a382e9ca6.png" width="300"/>