### PR TITLE
Replace old Rotate Layout icon

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -117,6 +117,11 @@
   background-color: #734f96   !important;
   color: white;
 }
+.rotate_span {
+  font-weight : "bolder";
+  font-size:"24px";
+  color:"white";
+}
 
 .btn-light {
   background-color: #F7F7F7 !important;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -117,11 +117,6 @@
   background-color: #734f96   !important;
   color: white;
 }
-.rotate_span {
-  font-weight : "bolder";
-  font-size:"24px";
-  color:"white";
-}
 
 .btn-light {
   background-color: #F7F7F7 !important;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -155,7 +155,7 @@ function App() {
 		}
 	};
 
-	const HorizontalLayoutIcon = () => {
+	const LayoutIcon = ({ portrait }) => {
 		return (
 			<div style={{
 				width: "24px",
@@ -163,21 +163,7 @@ function App() {
 				border: "2px solid white",
 				margin: "0 auto",
 				borderRadius : "3px",
-				transform: "rotate(90deg)"
-			}}>
-				<span style={{ border: "0.1px solid white", borderBottom: "0px" }}></span>
-			</div>
-		)
-	}
-
-	const VerticalLayoutIcon = () => {
-		return (
-			<div style={{
-				width: "24px",
-				height: "24px",
-				border: "2px solid white",
-				borderRadius : "3px",
-				margin: "0 auto",
+				transform: (portrait ? "none" : "rotate(90deg)")
 			}}>
 				<span style={{ border: "0.1px solid white", borderBottom: "0px" }}></span>
 			</div>
@@ -211,7 +197,7 @@ function App() {
 						<Stack style={{ color: 'white', fontSize: '24px' }} />
 					</Button>
 					<Button title='Layout' className='selector' variant='rotate' onClick={handleLayout}>
-						{!potrait ? <HorizontalLayoutIcon /> : <VerticalLayoutIcon />}
+						<LayoutIcon portrait={potrait} />
 					</Button>
 					<Button
 						title={theme === 'monokai' ? 'Light Mode' : 'Dark Mode'}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,9 +18,7 @@ import {
 	MoonStarsFill,
 	PlayFill,
 	Stack,
-	SunFill,
-	SymmetryHorizontal,
-	SymmetryVertical,
+	SunFill
 } from 'react-bootstrap-icons';
 //Function to push \n in string to new lines
 function NewlineText(props) {
@@ -157,6 +155,35 @@ function App() {
 		}
 	};
 
+	const HorizontalLayoutIcon = () => {
+		return (
+			<div style={{
+				width: "24px",
+				height: "24px",
+				border: "2px solid white",
+				margin: "0 auto",
+				borderRadius : "3px",
+				transform: "rotate(90deg)"
+			}}>
+				<span style={{ border: "0.1px solid white", borderBottom: "0px" }}></span>
+			</div>
+		)
+	}
+
+	const VerticalLayoutIcon = () => {
+		return (
+			<div style={{
+				width: "24px",
+				height: "24px",
+				border: "2px solid white",
+				borderRadius : "3px",
+				margin: "0 auto",
+			}}>
+				<span style={{ border: "0.1px solid white", borderBottom: "0px" }}></span>
+			</div>
+		)
+	}
+
 	return (
 		<div className='App' onLoad={loadCode} tabIndex={0} onKeyDown={handleKeyDown}>
 			{/*Navbar*/}
@@ -184,11 +211,7 @@ function App() {
 						<Stack style={{ color: 'white', fontSize: '24px' }} />
 					</Button>
 					<Button title='Layout' className='selector' variant='rotate' onClick={handleLayout}>
-						{!potrait ? (
-							<SymmetryHorizontal style={{ color: 'white', fontSize: '24px' }} />
-						) : (
-							<SymmetryVertical style={{ color: 'white', fontSize: '24px' }} />
-						)}
+						{!potrait ? <HorizontalLayoutIcon /> : <VerticalLayoutIcon />}
 					</Button>
 					<Button
 						title={theme === 'monokai' ? 'Light Mode' : 'Dark Mode'}


### PR DESCRIPTION
Hello, @milancurcic  @Shaikh-Ubaid I have made some changes to the Rotate icon. Initially, I tried to replace it with the ◫ Unicode Character, but unfortunately, the size of the icon was smaller compared to the other icons. Despite trying to increase its font size and width, I was unable to find a suitable solution.

![small_pic](https://user-images.githubusercontent.com/77038993/224469760-413823ae-514c-4a1a-937d-e1c505b9aa6d.PNG)

As an alternative, I decided to create a new icon from scratch using pure HTML and CSS, and I am pleased to inform you that it is now functioning properly. 
Here is the demo of the new icon :

![image](https://user-images.githubusercontent.com/77038993/224469829-919f5666-bff5-48f2-aede-a3868b1b2f91.png)
